### PR TITLE
feat: Replace use_script_friendly_output with output_format_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,30 @@
 # Changelog
 
-## [0.3.0] - 2025-05-19
+## [0.4.0] - 2025-05-20
+- Replaced the `use_script_friendly_output` boolean parameter with a more versatile `output_format_mode` string enum parameter for the `execute_script` tool. This provides finer-grained control over `osascript` output formatting flags.
+  - New parameter: `output_format_mode` (enum: `'auto'`, `'human_readable'`, `'structured_error'`, `'structured_output_and_error'`, `'direct'`, default: `'auto'`).
+  - The `'auto'` mode intelligently selects output formatting: `human_readable` (`-s h`) for AppleScript, and `direct` (no `-s` flags) for JXA, which is recommended for JXA compatibility, especially with Obj-C bridging.
+  - `use_script_friendly_output` has been removed.
+- Fixed a bug causing script execution time to be incorrectly reported as "0 milliseconds" for some scripts; timing is now measured with millisecond precision.
+- Refined the display formatting for reported execution times, including how sub-millisecond durations and spacing are handled.
 
+## [0.3.0] - 2025-05-19
 - Included script execution time in the output of the `execute_script` tool. The `timings` object in the response now contains `execution_time_seconds` (duration of the script execution itself in seconds, with up to two decimal places).
 - Increased the default script execution timeout (`timeoutSeconds`) from 30 seconds to 60 seconds.
 - Optimized and shortened the description for the `execute_script` tool.
 - Changed tool input parameter naming convention from camelCase to snake_case for all tools (e.g., `kbScriptId` is now `kb_script_id`). Placeholder keys within script content (e.g., `--MCP_INPUT:keyName`) remain camelCase, with internal mapping handled by the server.
 
 ## 0.2.3 - 2025-05-16
-
 - Improve script execution error handling.
 - Restructure JXA examples.
 
 ## 0.2.2 - 2025-05-16
-
 - Limit search output to 500 lines to prevent overly large responses.
 
 ## 0.2.1 - 2025-05-16
-
 - Limit search to 10 items by default.
 
 ## 0.2.0 - 2025-05-16
-
 - Greatly increased knowledge base, esp. around web browsers & terminal.
 - Add a two-step fuzzy search to inspire agents.
 - Add default limit (10) for search results to improve response times.
@@ -33,5 +36,4 @@
 - Moved CURSOR.md to .cursor/rules/agent.mdc for better compatibility with Cursor editor.
 
 ## 0.1.4 - 2025-05-15
-
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -85,32 +85,38 @@ Alternatively, for development or if you prefer to run the server directly from 
 ### 1. `execute_script`
 
 Executes an AppleScript or JavaScript for Automation (JXA) script on macOS. 
-Scripts can be provided as inline content (`scriptContent`), an absolute file path (`scriptPath`), or by referencing a script from the built-in knowledge base using its unique `kbScriptId`.
+Scripts can be provided as inline content (`script_content`), an absolute file path (`script_path`), or by referencing a script from the built-in knowledge base using its unique `kb_script_id`.
 
 **Script Sources (mutually exclusive):**
--   `scriptContent` (string): Raw script code.
--   `scriptPath` (string): Absolute POSIX path to a script file (e.g., `.applescript`, `.scpt`, `.js`).
--   `kbScriptId` (string): The ID of a pre-defined script from the server's knowledge base. Use the `get_scripting_tips` tool to discover available script IDs and their functionalities.
+-   `script_content` (string): Raw script code.
+-   `script_path` (string): Absolute POSIX path to a script file (e.g., `.applescript`, `.scpt`, `.js`).
+-   `kb_script_id` (string): The ID of a pre-defined script from the server's knowledge base. Use the `get_scripting_tips` tool to discover available script IDs and their functionalities.
 
 **Language Specification:**
 -   `language` (enum: 'applescript' | 'javascript', optional): Specify the language.
-    -   If using `kbScriptId`, the language is inferred from the knowledge base script.
-    -   If using `scriptContent` or `scriptPath` and `language` is omitted, it defaults to 'applescript'.
+    -   If using `kb_script_id`, the language is inferred from the knowledge base script.
+    -   If using `script_content` or `script_path` and `language` is omitted, it defaults to 'applescript'.
 
 **Passing Inputs to Scripts:**
 -   `arguments` (array of strings, optional): 
-    -   For `scriptPath`: Passed as standard arguments to the script's `on run argv` (AppleScript) or `run(argv)` (JXA) handler.
-    -   For `kbScriptId`: Used if the pre-defined script is designed to accept positional string arguments (e.g., replaces placeholders like `--MCP_ARG_1`, `--MCP_ARG_2`). Check the script's `argumentsPrompt` from `get_scripting_tips`.
--   `inputData` (JSON object, optional): 
-    -   Primarily for `kbScriptId` scripts designed to accept named, structured inputs.
+    -   For `script_path`: Passed as standard arguments to the script's `on run argv` (AppleScript) or `run(argv)` (JXA) handler.
+    -   For `kb_script_id`: Used if the pre-defined script is designed to accept positional string arguments (e.g., replaces placeholders like `--MCP_ARG_1`, `--MCP_ARG_2`). Check the script's `argumentsPrompt` from `get_scripting_tips`.
+-   `input_data` (JSON object, optional): 
+    -   Primarily for `kb_script_id` scripts designed to accept named, structured inputs.
     -   Values from this object replace placeholders in the script (e.g., `--MCP_INPUT:yourKeyName`). See `argumentsPrompt` from `get_scripting_tips`.
     -   Values (strings, numbers, booleans, simple arrays/objects) are converted to their AppleScript literal equivalents.
 
 **Other Options:**
--   `timeoutSeconds` (integer, optional, default: 30): Maximum execution time.
--   `useScriptFriendlyOutput` (boolean, optional, default: false): Uses `osascript -ss` flag for potentially more structured output, especially for lists and records.
--   `includeExecutedScriptInOutput` (boolean, optional, default: false): If true, the output will include the full script content (after any placeholder substitutions for knowledge base scripts) or the script path that was executed. This is appended as an additional text part in the output content array.
--   `includeSubstitutionLogs` (boolean, optional, default: false): If true, detailed logs of placeholder substitutions performed on knowledge base scripts are included in the output. This is useful for debugging how `inputData` and `arguments` are processed and inserted into the script. The logs are prepended to the script output on success or appended to the error message on failure.
+-   `timeout_seconds` (integer, optional, default: 60): Maximum execution time.
+-   `output_format_mode` (enum, optional, default: 'auto'): Controls `osascript` output formatting flags.
+    *   `'auto'`: (Default) Uses human-readable for AppleScript (`-s h`), and direct output (no `-s` flags) for JXA.
+    *   `'human_readable'`: Forces `-s h` (human-readable output, mainly for AppleScript).
+    *   `'structured_error'`: Forces `-s s` (structured error reporting, mainly for AppleScript).
+    *   `'structured_output_and_error'`: Forces `-s ss` (structured output for main result and errors, mainly for AppleScript).
+    *   `'direct'`: No `-s` flags are used (recommended for JXA, also the behavior for JXA in `auto` mode).
+-   `include_executed_script_in_output` (boolean, optional, default: false): If true, the output will include the full script content (after any placeholder substitutions for knowledge base scripts) or the script path that was executed. This is appended as an additional text part in the output content array.
+-   `include_substitution_logs` (boolean, optional, default: false): If true, detailed logs of placeholder substitutions performed on knowledge base scripts are included in the output. This is useful for debugging how `input_data` and `arguments` are processed and inserted into the script. The logs are prepended to the script output on success or appended to the error message on failure.
+-   `report_execution_time` (boolean, optional, default: false): If `true`, an additional message with the formatted script execution time will be included in the response content array.
 
 **SECURITY WARNING & MACOS PERMISSIONS:** (Same critical warnings as before about arbitrary script execution and macOS Automation/Accessibility permissions).
 
@@ -121,20 +127,20 @@ Scripts can be provided as inline content (`scriptContent`), an absolute file pa
     {
       "toolName": "execute_script",
       "input": {
-        "kbScriptId": "safari_get_active_tab_url",
-        "timeoutSeconds": 10
+        "kb_script_id": "safari_get_active_tab_url",
+        "timeout_seconds": 10
       }
     }
     ```
--   **Using Knowledge Base Script by ID with `inputData`:**
+-   **Using Knowledge Base Script by ID with `input_data`:**
     ```json
     {
       "toolName": "execute_script",
       "input": {
-        "kbScriptId": "finder_create_folder_at_path",
-        "inputData": {
-          "folderName": "New MCP Folder",
-          "parentPath": "~/Desktop"
+        "kb_script_id": "finder_create_folder_at_path",
+        "input_data": {
+          "folder_name": "New MCP Folder",
+          "parent_path": "~/Desktop"
         }
       }
     }
@@ -182,45 +188,46 @@ The `execute_script` tool returns a response in the following format:
 
 ### 2. `get_scripting_tips`
 
-Retrieves AppleScript/JXA tips, examples, and runnable script details from the server's knowledge base. Useful for discovering available scripts, their functionalities, and how to use them with `execute_script` (especially `kbScriptId`).
+Retrieves AppleScript/JXA tips, examples, and runnable script details from the server's knowledge base. Useful for discovering available scripts, their functionalities, and how to use them with `execute_script` (especially `kb_script_id`).
 
 **Arguments:**
--   `listCategories` (boolean, optional, default: false): If true, returns only the list of available knowledge base categories and their descriptions. Overrides other parameters.
+-   `list_categories` (boolean, optional, default: false): If true, returns only the list of available knowledge base categories and their descriptions. Overrides other parameters.
 -   `category` (string, optional): Filters tips by a specific category ID (e.g., "finder", "safari").
--   `searchTerm` (string, optional): Searches for a keyword within tip titles, descriptions, script content, keywords, or IDs.
--   `refreshDatabase` (boolean, optional, default: false): If true, forces a reload of the entire knowledge base from disk before processing the request. This is useful during development if you are actively modifying knowledge base files and want to ensure the latest versions are used without restarting the server.
+-   `search_term` (string, optional): Searches for a keyword within tip titles, descriptions, script content, keywords, or IDs.
+-   `refresh_database` (boolean, optional, default: false): If true, forces a reload of the entire knowledge base from disk before processing the request. This is useful during development if you are actively modifying knowledge base files and want to ensure the latest versions are used without restarting the server.
+-   `limit` (integer, optional, default: 10): Maximum number of results to return.
 
 **Output:**
 -   Returns a Markdown formatted string containing the requested tips, including their title, description, script content, language, runnable ID (if applicable), argument prompts, and notes.
 
 **Example Usage:**
 -   List all categories:
-    `{ "toolName": "get_scripting_tips", "input": { "listCategories": true } }`
+    `{ "toolName": "get_scripting_tips", "input": { "list_categories": true } }`
 -   Get tips for "safari" category:
     `{ "toolName": "get_scripting_tips", "input": { "category": "safari" } }`
 -   Search for tips related to "clipboard":
-    `{ "toolName": "get_scripting_tips", "input": { "searchTerm": "clipboard" } }`
+    `{ "toolName": "get_scripting_tips", "input": { "search_term": "clipboard" } }`
 
 ## Key Use Cases & Examples
 
 -   **Application Control:**
-    -   Get the current URL from Safari: `{ "scriptContent": "tell application \"Safari\" to get URL of front document" }`
-    -   Get subjects of unread emails in Mail: `{ "scriptContent": "tell application \"Mail\" to get subject of messages of inbox whose read status is false" }`
+    -   Get the current URL from Safari: `{ "input": { "script_content": "tell application \"Safari\" to get URL of front document" } }`
+    -   Get subjects of unread emails in Mail: `{ "input": { "script_content": "tell application \"Mail\" to get subject of messages of inbox whose read status is false" } }`
 -   **File System Operations:**
-    -   List files on the Desktop: `{ "scriptContent": "tell application \"Finder\" to get name of every item of desktop" }`
-    -   Create a new folder: `{ "scriptContent": "tell application \"Finder\" to make new folder at desktop with properties {name:\"My New Folder\"}" }`
+    -   List files on the Desktop: `{ "input": { "script_content": "tell application \"Finder\" to get name of every item of desktop" } }`
+    -   Create a new folder: `{ "input": { "script_content": "tell application \"Finder\" to make new folder at desktop with properties {name:\"My New Folder\"}" } }`
 -   **System Interactions:**
-    -   Display a system notification: `{ "scriptContent": "display notification \"Important Update!\" with title \"System Alert\"" }`
-    -   Set system volume: `{ "scriptContent": "set volume output volume 50" }` (0-100)
-    -   Get current clipboard content: `{ "scriptContent": "the clipboard" }`
+    -   Display a system notification: `{ "input": { "script_content": "display notification \"Important Update!\" with title \"System Alert\"" } }`
+    -   Set system volume: `{ "input": { "script_content": "set volume output volume 50" } }` (0-100)
+    -   Get current clipboard content: `{ "input": { "script_content": "the clipboard" } }`
 
 ## Troubleshooting
 
 -   **Permissions Errors:** If scripts fail to control apps or perform UI actions, double-check Automation and Accessibility permissions in System Settings for the application running the MCP server (e.g., Terminal).
 -   **Script Syntax Errors:** `osascript` errors will be returned in the `stderr` or error message. Test complex scripts locally using Script Editor (for AppleScript) or a JXA runner first.
--   **Timeouts:** If a script takes longer than `timeoutSeconds` (default 30s), it will be terminated. Increase the timeout for long-running scripts.
--   **File Not Found:** Ensure `scriptPath` is an absolute POSIX path accessible by the user running the MCP server.
--   **Incorrect Output:** Experiment with `useScriptFriendlyOutput: true` if the default human-readable output is not suitable for parsing (especially for lists or records).
+-   **Timeouts:** If a script takes longer than `timeout_seconds` (default 60s), it will be terminated. Increase the timeout for long-running scripts.
+-   **File Not Found:** Ensure `script_path` is an absolute POSIX path accessible by the user running the MCP server.
+-   **Incorrect Output/JXA Issues:** For JXA scripts, especially those using Objective-C bridging, ensure `output_format_mode` is set to `'direct'` or `'auto'` (default). Using AppleScript-specific formatting flags like `human_readable` with JXA can cause errors. If AppleScript output is not parsing correctly, try `structured_output_and_error` or `structured_error`.
 
 ## Configuration via Environment Variables
 
@@ -230,7 +237,7 @@ Retrieves AppleScript/JXA tips, examples, and runnable script details from the s
 
 -   `KB_PARSING`: Controls when the knowledge base (script tips) is parsed.
     -   Values:
-        -   `lazy` (default): The knowledge base is parsed on the first request to `get_scripting_tips` or when a `kbScriptId` is used in `execute_script`. This allows for faster server startup.
+        -   `lazy` (default): The knowledge base is parsed on the first request to `get_scripting_tips` or when a `kb_script_id` is used in `execute_script`. This allows for faster server startup.
         -   `eager`: The knowledge base is parsed when the server starts up. This may slightly increase startup time but ensures the KB is immediately available and any parsing errors are caught early.
     -   Example (when running via `start.sh` or similar):
         ```bash
@@ -291,7 +298,7 @@ This server provides powerful macOS automation capabilities through AppleScript 
 ### Terminal Automation
 - **Run commands in new Terminal tabs:**
   ```
-  { "kbScriptId": "terminal_app_run_command_new_tab", "inputData": { "command": "ls -la" } }
+  { "input": { "kb_script_id": "terminal_app_run_command_new_tab", "input_data": { "command": "ls -la" } } }
   ```
 - **Execute commands with sudo and provide password securely**
 - **Capture command output for processing**
@@ -299,14 +306,14 @@ This server provides powerful macOS automation capabilities through AppleScript 
 ### Browser Control
 - **Chrome/Safari automation:**
   ```
-  { "kbScriptId": "chrome_open_url_new_tab_profile", "inputData": { "url": "https://example.com", "profileName": "Default" } }
+  { "input": { "kb_script_id": "chrome_open_url_new_tab_profile", "input_data": { "url": "https://example.com", "profile_name": "Default" } } }
   ```
   ```
-  { "kbScriptId": "safari_get_front_tab_url" }
+  { "input": { "kb_script_id": "safari_get_front_tab_url" } }
   ```
 - **Execute JavaScript in browser context:**
   ```
-  { "kbScriptId": "chrome_execute_javascript", "inputData": { "javascript": "document.title" } }
+  { "input": { "kb_script_id": "chrome_execute_javascript", "input_data": { "javascript_code": "document.title" } } }
   ```
 - **Extract page content, manipulate forms, and automate workflows**
 - **Take screenshots of web pages**
@@ -314,11 +321,11 @@ This server provides powerful macOS automation capabilities through AppleScript 
 ### System Interaction
 - **Toggle system settings (dark mode, volume, network):**
   ```
-  { "kbScriptId": "systemsettings_toggle_dark_mode_ui" }
+  { "input": { "kb_script_id": "systemsettings_toggle_dark_mode_ui" } }
   ```
 - **Get/set clipboard content:**
   ```
-  { "kbScriptId": "system_clipboard_get_file_paths" }
+  { "input": { "kb_script_id": "system_clipboard_get_file_paths" } }
   ```
 - **Open/control system dialogs and alerts**
 - **Create and manage system notifications**
@@ -326,11 +333,11 @@ This server provides powerful macOS automation capabilities through AppleScript 
 ### File Operations
 - **Create, move, and manipulate files/folders:**
   ```
-  { "kbScriptId": "finder_create_new_folder_desktop", "inputData": { "folderName": "My Project" } }
+  { "input": { "kb_script_id": "finder_create_new_folder_desktop", "input_data": { "folder_name": "My Project" } } }
   ```
 - **Read and write text files:**
   ```
-  { "kbScriptId": "fileops_read_text_file", "inputData": { "filePath": "~/Documents/notes.txt" } }
+  { "input": { "kb_script_id": "fileops_read_text_file", "input_data": { "file_path": "~/Documents/notes.txt" } } }
   ```
 - **List and filter files in directories**
 - **Get file metadata and properties**
@@ -338,15 +345,15 @@ This server provides powerful macOS automation capabilities through AppleScript 
 ### Application Integration
 - **Calendar/Reminders management:**
   ```
-  { "kbScriptId": "calendar_create_event", "inputData": { "title": "Meeting", "startDate": "2023-06-01 10:00", "endDate": "2023-06-01 11:00" } }
+  { "input": { "kb_script_id": "calendar_create_event", "input_data": { "title": "Meeting", "start_date": "2023-06-01 10:00", "end_date": "2023-06-01 11:00" } } }
   ```
 - **Email automation with Mail.app:**
   ```
-  { "kbScriptId": "mail_send_email_direct", "inputData": { "recipient": "user@example.com", "subject": "Hello", "body": "Message content" } }
+  { "input": { "kb_script_id": "mail_send_email_direct", "input_data": { "recipient": "user@example.com", "subject": "Hello", "body_content": "Message content" } } }
   ```
 - **Control music playback:**
   ```
-  { "kbScriptId": "music_playback_controls", "inputData": { "action": "play" } }
+  { "input": { "kb_script_id": "music_playback_controls", "input_data": { "action": "play" } } }
   ```
 - **Work with creative apps (Keynote, Pages, Numbers)**
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -10,22 +10,33 @@ const DynamicScriptingKnowledgeCategoryEnum = z.string()
     .describe("Category of AppleScript/JXA tips. Should match a discovered category ID from the knowledge base.");
 
 export const ExecuteScriptInputSchema = z.object({
-  script_content: z.string().optional()
-    .describe("Raw AppleScript/JXA code. Mutually exclusive with `script_path` & `kb_script_id`."),
-  script_path: z.string().optional()
-    .describe("Absolute POSIX path to a script file. Mutually exclusive with `script_content` & `kb_script_id`."),
-  kb_script_id: z.string().optional()
-    .describe("Unique ID of a pre-defined script from the knowledge base. Mutually exclusive with `script_content` & `script_path`. Use 'get_scripting_tips' to find IDs."),
-  language: z.enum(['applescript', 'javascript']).optional()
-    .describe("Scripting language. Inferred if using `kb_script_id`. Defaults to 'applescript' if using `script_content`/`script_path` and not specified."),
-  arguments: z.array(z.string()).optional().default([])
-    .describe("String arguments for `script_path` scripts ('on run argv'). For `kb_script_id`, used if script is designed for positional string args (see tip's 'argumentsPrompt')."),
-  input_data: z.record(z.string(), z.any()).optional() 
-    .describe("JSON object providing named input data for `kb_script_id` scripts designed to accept structured input (see tip's 'argumentsPrompt'). Replaces placeholders like --MCP_INPUT:keyName."),
-  timeout_seconds: z.number().int().positive().optional().default(60)
-    .describe("Script execution timeout in seconds."),
-  use_script_friendly_output: z.boolean().optional().default(false)
-    .describe("Use 'osascript -ss' for script-friendly output."),
+  kb_script_id: z.string().optional().describe(
+    'The ID of a knowledge base script to execute. Replaces script_content and script_path if provided.',
+  ),
+  script_content: z.string().optional().describe(
+    'The content of the script to execute. Required if kb_script_id or script_path is not provided.',
+  ),
+  script_path: z.string().optional().describe(
+    'The path to the script file to execute. Required if kb_script_id or script_content is not provided.',
+  ),
+  arguments: z.array(z.string()).optional().describe(
+    'Optional arguments to pass to the script. For AppleScript, these are passed to the main `run` handler. For JXA, these are passed to the `run` function.',
+  ),
+  input_data: z.record(z.unknown()).optional().describe(
+    'Optional JSON object to provide named inputs for --MCP_INPUT placeholders in knowledge base scripts.',
+  ),
+  language: z.enum(['applescript', 'javascript']).optional().describe(
+    "Specifies the scripting language. Crucial for `script_content` and `script_path` if not 'applescript'. Defaults to 'applescript'. Inferred if using `kb_script_id`.",
+  ),
+  timeout_seconds: z.number().int().optional().default(60).describe(
+    'The timeout for the script execution in seconds. Defaults to 60.',
+  ),
+  output_format_mode: z.enum(['auto', 'human_readable', 'structured_error', 'structured_output_and_error', 'direct']).optional().default('auto').describe(
+    "Controls osascript output formatting. \n'auto': (Default) Smart selection based on language (AppleScript: human_readable, JXA: direct). \n'human_readable': AppleScript -s h. \n'structured_error': AppleScript -s s. \n'structured_output_and_error': AppleScript -s ss. \n'direct': No -s flags (recommended for JXA)."
+  ),
+  report_execution_time: z.boolean().optional().default(false).describe(
+    'If true, the tool will return an additional message containing the formatted script execution time. Defaults to false.',
+  ),
   include_executed_script_in_output: z.boolean().optional().default(false)
     .describe("If true, the executed script content (after substitutions) or path will be included in the output."),
   include_substitution_logs: z.boolean().optional().default(false)

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import * as sdkTypes from '@modelcontextprotocol/sdk/types.js';
 import { Logger } from './logger.js';
 import { ExecuteScriptInputSchema, GetScriptingTipsInputSchema } from './schemas.js';
 import { ScriptExecutor } from './ScriptExecutor.js';
-import type { ScriptExecutionError }  from './types.js';
+import type { ScriptExecutionError, ExecuteScriptResponse }  from './types.js';
 // import pkg from '../package.json' with { type: 'json' }; // Import package.json // REMOVED
 import { getKnowledgeBase, getScriptingTipsService, conditionallyInitializeKnowledgeBase } from './services/knowledgeBaseService.js'; // Import KB functions
 import { substitutePlaceholders } from './placeholderSubstitutor.js'; // Value import
@@ -21,7 +21,6 @@ import { z } from 'zod';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { realpathSync } from 'node:fs';
 
 // Robustly load package.json
 const __filenameServer = fileURLToPath(import.meta.url);
@@ -41,9 +40,6 @@ try {
 }
 
 const SERVER_START_TIME_ISO = new Date().toISOString();
-const SCRIPT_PATH_EXECUTED = process.argv[1] || 'unknown_path';
-const IS_RUNNING_FROM_SRC = SCRIPT_PATH_EXECUTED.includes('/src/server.ts') || SCRIPT_PATH_EXECUTED.endsWith('/src/server.ts');
-const EXECUTION_MODE_INFO = IS_RUNNING_FROM_SRC ? 'TypeScript source (e.g., via tsx)' : 'Compiled JavaScript (e.g., dist/server.js)';
 
 const IS_E2E_TESTING = process.env.MCP_E2E_TESTING === 'true' || process.env.VITEST === 'true';
 let hasEmittedFirstCallInfo = false; // Flag for first tool call
@@ -61,9 +57,10 @@ const ExecuteScriptInputShape = {
   arguments: z.array(z.string()).optional(),
   input_data: z.record(z.any()).optional(),
   timeout_seconds: z.number().optional(),
-  use_script_friendly_output: z.boolean().optional(),
   include_executed_script_in_output: z.boolean().optional(),
   include_substitution_logs: z.boolean().optional(),
+  report_execution_time: z.boolean().optional(),
+  output_format_mode: z.enum(['auto', 'human_readable', 'structured_error', 'structured_output_and_error', 'direct']).optional(),
 } as const;
 
 const GetScriptingTipsInputShape = {
@@ -117,10 +114,17 @@ async function main() {
 
 **3. Execution Options (Optional):**
 *   \`language\` ('applescript' | 'javascript'): Specify for \`script_content\`/\`script_path\` (default: 'applescript'). Inferred for \`kb_script_id\`.
-*   \`timeout_seconds\` (integer, default: 60): Max script runtime.
-*   \`use_script_friendly_output\` (boolean, default: false): Use \`osascript -ss\` for structured output.
-*   \`include_executed_script_in_output\` (boolean, default: false): Appends executed script/path to output.
-*   \`include_substitution_logs\` (boolean, default: false): For \`kb_script_id\`, includes detailed placeholder substitution logs.`,
+*   \`timeout_seconds\` (integer, optional, default: 60): Sets the maximum time (in seconds) the script is allowed to run. Increase for potentially long-running operations.
+*   \`output_format_mode\` (enum, optional, default: 'auto'): Controls \`osascript\` output formatting.
+    *   \`'auto'\`: Smart default - resolves to \`'human_readable'\` for AppleScript and \`'direct'\` for JXA.
+    *   \`'human_readable'\`: For AppleScript, uses \`-s h\` flag.
+    *   \`'structured_error'\`: For AppleScript, uses \`-s s\` flag (structured errors).
+    *   \`'structured_output_and_error'\`: For AppleScript, uses \`-s ss\` flag (structured output & errors).
+    *   \`'direct'\`: No special output flags (recommended for JXA).
+*   \`include_executed_script_in_output\` (boolean, optional, default: false): If \`true\`, the final script content (after any placeholder substitutions) or script path that was executed will be included in the response. This is useful for debugging and understanding exactly what was run. Defaults to false.
+*   \`include_substitution_logs\` (boolean, default: false): For \`kb_script_id\`, includes detailed placeholder substitution logs.
+*   \`report_execution_time\` (boolean, optional, default: false): If \`true\`, an additional message with the formatted script execution time will be included in the response. Defaults to false.
+`,
     ExecuteScriptInputShape,
     async (args: unknown) => {
       const input = ExecuteScriptInputSchema.parse(args);
@@ -188,7 +192,7 @@ async function main() {
           {
             language: languageToUse,
             timeoutMs: (input.timeout_seconds || 60) * 1000,
-            useScriptFriendlyOutput: input.use_script_friendly_output || false,
+            output_format_mode: input.output_format_mode || 'auto',
             arguments: scriptPathToExecute ? finalArgumentsForScriptFile : [], 
           }
         );
@@ -228,18 +232,37 @@ async function main() {
         finalResponseContent.push(...mainOutputContent); // Add the actual script output
 
         if (!IS_E2E_TESTING && !hasEmittedFirstCallInfo) {
-          finalResponseContent.push({ type: 'text', text: '---' }); // Separator
           finalResponseContent.push({ type: 'text', text: serverInfoMessage });
           hasEmittedFirstCallInfo = true;
         }
 
-        return {
+        const response: ExecuteScriptResponse = {
           content: finalResponseContent,
           isError,
-          timings: { execution_time_seconds }
         };
 
+        if (input.report_execution_time) {
+          const ms = result.execution_time_seconds * 1000;
+          let timeMessage = "Script executed in ";
+          if (ms < 1) { // Less than 1 millisecond
+            timeMessage += "<1 millisecond.";
+          } else if (ms < 1000) { // 1ms up to 999ms
+            timeMessage += `${ms.toFixed(0)} milliseconds.`;
+          } else if (ms < 60000) { // 1 second up to 59.999 seconds
+            timeMessage += `${(ms / 1000).toFixed(2)} seconds.`;
+          } else {
+            const totalSeconds = ms / 1000;
+            const minutes = Math.floor(totalSeconds / 60);
+            const remainingSeconds = Math.round(totalSeconds % 60);
+            timeMessage += `${minutes} minute(s) and ${remainingSeconds} seconds.`;
+          }
+          response.content.push({ type: 'text', text: `${timeMessage}` });
+        }
+
+        return response;
+
       } catch (error: unknown) {
+        const typedError = error as ScriptExecutionError;
         const execError = error as ScriptExecutionError;
         execution_time_seconds = execError.execution_time_seconds;
 
@@ -282,7 +305,37 @@ async function main() {
 
         logger.error('execute_script handler error', { execution_time_seconds });
 
-        throw new sdkTypes.McpError(sdkTypes.ErrorCode.InternalError, finalErrorMessage);
+        // Construct a complete error response, with potential first-call info
+        const errorOutputParts: string[] = [finalErrorMessage];
+        if (!IS_E2E_TESTING && !hasEmittedFirstCallInfo) {
+          errorOutputParts.push(serverInfoMessage);
+          hasEmittedFirstCallInfo = true;
+        }
+        
+        const errorResponse: ExecuteScriptResponse = {
+          content: [{ type: 'text', text: errorOutputParts.join('\n\n') }],
+          isError: true,
+        };
+        
+        if (input.report_execution_time && typedError.execution_time_seconds !== undefined) {
+          const ms = typedError.execution_time_seconds * 1000;
+          let timeMessage = "Script execution failed after ";
+          if (ms < 1) { // Less than 1 millisecond
+            timeMessage += "<1 millisecond.";
+          } else if (ms < 1000) { // 1ms up to 999ms
+            timeMessage += `${ms.toFixed(0)} milliseconds.`;
+          } else if (ms < 60000) { // 1 second up to 59.999 seconds
+            timeMessage += `${(ms / 1000).toFixed(2)} seconds.`;
+          } else {
+            const totalSeconds = ms / 1000;
+            const minutes = Math.floor(totalSeconds / 60);
+            const remainingSeconds = Math.round(totalSeconds % 60);
+            timeMessage += `${minutes} minute(s) and ${remainingSeconds} seconds.`;
+          }
+          errorResponse.content.push({ type: 'text', text: `\n${timeMessage}` });
+        }
+        
+        return errorResponse;
       }
     }
   );
@@ -301,109 +354,60 @@ async function main() {
 
 *   **Limiting Search Results (Use \`limit\`):**
     *   Parameter: \`limit\` (integer, optional, default: 10).
-    *   Functionality: Specifies the maximum number of script tips to return when using \`search_term\` or browsing a specific \`category\` (without \`list_categories: true\`). Does not apply if \`list_categories\` is true. If more tips are found than the limit, a notice will indicate this.
-    *   Output: The list of tips will be truncated to this number if applicable.
+    *   Functionality: Specifies the maximum number of script tips to return when using \`search_term\` or browsing a specific \`category\` (without \`list_categories: true\`). Does not apply if \`list_categories\` is true.
 
-*   **Listing All Categories (Use \`list_categories\`):**
-    *   Parameter: \`list_categories\` (boolean, optional, default: false).
-    *   Functionality: If \`true\`, this will return a list of all available script categories (e.g., "safari", "finder_operations", "system_interaction") along with their descriptions and the number of tips in each. This overrides other parameters, including \`limit\`.
-    *   Output: A Markdown list of categories.
-
-*   **Browsing a Specific Category (Use \`category\`):**
+*   **Browsing by Category (Use \`category\`):**
     *   Parameter: \`category\` (string, optional).
-    *   Functionality: Retrieves all tips belonging to the specified category ID. Useful if you know the general area of automation you're interested in. Results can be limited by the \`limit\` parameter.
-    *   Output: All tips within that category, formatted in Markdown (potentially limited).
+    *   Functionality: Shows tips from a specific category. Combine with \`limit\` to control result count.
+    *   Example: \`category: "01_intro"\` or \`category: "07_browsers/chrome"\`.
 
-*   **Forcing a Knowledge Base Reload (Use \`refresh_database\`):**
-    *   Parameter: \`refresh_database\` (boolean, optional, default: false).
-    *   Functionality: If \`true\`, forces the server to reload the entire knowledge base from disk before processing the request. Primarily useful during development if knowledge base files are being actively modified and you need to ensure the latest versions are reflected without a server restart.
+*   **Listing All Categories (Use \`list_categories: true\`):**
+    *   Parameter: \`list_categories\` (boolean, optional).
+    *   Functionality: Returns a structured list of all available categories with their descriptions. This helps you understand what automation areas are covered.
+    *   Output: Category tree in Markdown format.
 
-**Output Details:**
-The tool returns a single Markdown formatted string. Each tip in the output typically includes:
-- Title: A human-readable title for the tip.
-- Description: A brief explanation of what the script does.
-- Language: \`applescript\` or \`javascript\`.
-- Script: The actual code snippet.
-- Runnable ID: A unique identifier (e.g., \`safari_get_front_tab_url\`). **This ID is critical as it can be directly used as the \`kbScriptId\` parameter in the \`execute_script\` tool for immediate execution.**
-- Arguments Prompt: If the script is designed to take inputs when run by ID, this field describes what \`arguments\` or \`inputData\` are expected by \`execute_script\`.
-- Keywords: Relevant search terms.
-- Notes: Additional context or important considerations.
+*   **Refreshing Database (Use \`refresh_database: true\`):**
+    *   Parameter: \`refresh_database\` (boolean, optional).
+    *   Functionality: Forces a reload of the knowledge base if new scripts have been added. Typically not needed as the database refreshes automatically.
 
-**Workflow Example:**
-1. User asks: "How do I create a new note in the Notes app with a specific title?"
-2. Agent calls \`get_scripting_tips\` with \`search_term: "create new note in Notes app with title"\`.
-3. Agent reviews the output. If a tip like \`notes_create_new_note_with_title\` with a \`Runnable ID\` and an \`argumentsPrompt\` for \`noteTitle\` and \`noteBody\` is found:
-4. Agent then calls \`execute_script\` with \`kb_script_id: "notes_create_new_note_with_title"\` and appropriate \`input_data\`.`,
+**Best Practices:**
+1. **Always start with search**: Use natural language queries to find solutions (e.g., "send email from Mail app").
+2. **Browse categories when exploring**: Use \`list_categories: true\` to see available automation areas.
+3. **Use specific IDs for execution**: Once you find a script, use its ID with \`execute_script\` tool for precise execution.`,
     GetScriptingTipsInputShape,
     async (args: unknown) => {
       const input = GetScriptingTipsInputSchema.parse(args);
-      logger.info('get_scripting_tips tool called', input);
-      try {
-        const serverInfoForService = { startTime: SERVER_START_TIME_ISO, mode: EXECUTION_MODE_INFO, version: pkg.version };
-        const tipsMarkdown = await getScriptingTipsService(input, serverInfoForService);
+      
+      // Call getScriptingTipsService directly with the input parameters
+      let content = await getScriptingTipsService(input);
 
-        const finalResponseContent: { type: 'text'; text: string }[] = [];
-        finalResponseContent.push({ type: 'text', text: tipsMarkdown });
-
-        if (!IS_E2E_TESTING && !hasEmittedFirstCallInfo) {
-          finalResponseContent.push({ type: 'text', text: '---' }); // Separator
-          finalResponseContent.push({ type: 'text', text: serverInfoMessage });
-          hasEmittedFirstCallInfo = true;
-        }
-
-        return { content: finalResponseContent } as const;
-      } catch (e: unknown) {
-        const error = e as Error;
-        logger.error('Error in get_scripting_tips tool handler', { message: error.message });
-        throw new sdkTypes.McpError(sdkTypes.ErrorCode.InternalError, `Failed to retrieve scripting tips: ${error.message}`);
+      // Append first-call info if applicable
+      if (!IS_E2E_TESTING && !hasEmittedFirstCallInfo) {
+        content += '\n\n' + serverInfoMessage;
+        hasEmittedFirstCallInfo = true;
       }
+
+      return {
+        content: [{
+          type: 'text',
+          text: content
+        }]
+      };
     }
   );
 
   const transport = new StdioServerTransport();
-  try {
-    await server.connect(transport);
-    // Only log ready message if not in E2E testing, to keep stdout clean for inspector
-    if (!IS_E2E_TESTING) {
-      logger.info(`macos_automator MCP Server v${pkg.version} connected via STDIO and ready.`);
-    }
-  } catch (error: unknown) { // Changed from any to unknown
-    const connectError = error as Error;
-    logger.error('Failed to connect server to transport', { message: connectError.message, stack: connectError.stack });
-    process.exit(1);
-  }
-}
+  await server.connect(transport);
 
-// Graceful shutdown
-const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGQUIT'];
-for (const signal of signals) {
-  process.on(signal, () => {
-    logger.info(`Received ${signal}, shutting down server...`);
-    // Perform any cleanup if necessary
+  // Graceful shutdown
+  process.on('SIGINT', async () => {
+    logger.info('Shutting down macos_automator MCP Server...');
+    await server.close();
     process.exit(0);
   });
 }
 
-// Global error handlers
-process.on('uncaughtException', (error) => {
-  logger.error('Uncaught Exception:', { message: error.message, stack: error.stack });
+main().catch((error) => {
+  logger.error('Fatal error in server', error);
   process.exit(1);
 });
-
-process.on('unhandledRejection', (reason, promise) => {
-  logger.error('Unhandled Rejection at:', { promise, reason: reason instanceof Error ? reason.message : reason });
-  process.exit(1);
-});
-
-// Execute main() if this module is the entry point, even when invoked via a symlinked CLI script
-try {
-  const executedPath = realpathSync(process.argv[1] || '');
-  const modulePath = realpathSync(fileURLToPath(import.meta.url));
-  if (executedPath === modulePath) {
-    await main();
-  }
-} catch (error) {
-  const mainError = error as Error;
-  logger.error("Fatal error during server startup:", { message: mainError.message, stack: mainError.stack });
-  process.exit(1);
-} 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,8 +4,8 @@ export type LogLevel = 'DEBUG' | 'INFO' | 'WARN' | 'ERROR';
 export interface ScriptExecutionOptions {
   language?: 'applescript' | 'javascript';
   timeoutMs?: number;
-  useScriptFriendlyOutput?: boolean;
-  arguments?: string[]; // For script files
+  output_format_mode?: 'auto' | 'human_readable' | 'structured_error' | 'structured_output_and_error' | 'direct';
+  arguments?: string[]; // For script files executed via path
 }
 
 export interface ScriptExecutionResult {
@@ -23,17 +23,86 @@ export interface ScriptExecutionError extends Error {
   killed?: boolean; // Specifically for timeouts
   originalError?: unknown; // The raw error from child_process
   isTimeout?: boolean;
-  execution_time_seconds?: number; // Renamed and kept for error context
+  execution_time_seconds: number; // Changed from optional to required
 }
 
-// MCP Tool Response Types
+// MCP Error structure
+export interface McpError extends Error {
+  details?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | string | null;
+  signal?: string | null;
+  killed?: boolean;
+  originalError?: unknown;
+  isTimeout?: boolean;
+  execution_time_seconds?: number;
+}
+
+export interface ExecuteScriptInput {
+  /**
+   * The content of the script to execute. Either this or script_path must be provided.
+   */
+  script_content?: string;
+  /**
+   * The path to the script file to execute. Either this or script_content must be provided.
+   */
+  script_path?: string;
+  /**
+   * Optional arguments to pass to the script. For AppleScript, these are passed to the main `run` handler.
+   * For JXA, these are passed to the `run` function.
+   */
+  arguments?: string[];
+  /**
+   * Optional JSON object to provide named inputs for --MCP_INPUT placeholders in knowledge base scripts.
+   */
+  input_data?: Record<string, unknown>;
+  /**
+   * The timeout for the script execution in seconds. Defaults to 60.
+   * @default 60
+   */
+  timeout_seconds?: number;
+  /**
+   * If true, the tool will return an additional message containing the formatted script execution time.
+   * @default false
+   */
+  report_execution_time?: boolean;
+  /**
+   * Controls the output formatting flags for osascript. 
+   * 'auto': (Default) Uses human-readable for AppleScript, direct for JXA.
+   * 'human_readable': Uses -s h.
+   * 'structured_error': Uses -s s.
+   * 'structured_output_and_error': Uses -s ss.
+   * 'direct': No -s flags.
+   * @default auto
+   */
+  output_format_mode?: 'auto' | 'human_readable' | 'structured_error' | 'structured_output_and_error' | 'direct';
+}
+
+/**
+ * Represents the output of the script_executor.
+ */
+export interface ScriptExecutorResult {
+  /** The stdout from the script. */
+  stdout: string;
+  /** The stderr from the script. */
+  stderr: string;
+  /** The error object if the script failed. */
+  error?: Error | McpError;
+  /** The execution time in milliseconds. */
+  executionTimeMs: number;
+  /** Indicates if the script timed out. */
+  timedOut: boolean;
+}
+
+/**
+ * Defines the overall response structure for the execute_script tool.
+ */
 export interface ExecuteScriptResponse {
   content: Array<{
     type: 'text';
     text: string;
   }>;
   isError?: boolean;
-  timings?: {
-    execution_time_seconds?: number;
-  };
+  [key: string]: unknown; // Required by MCP SDK for tool responses
 } 


### PR DESCRIPTION
## Summary
- Introduces a more versatile `output_format_mode` parameter to replace the boolean `use_script_friendly_output`
- Fixes script execution timing precision issue (was showing 0ms)
- Adds optional execution time reporting via `report_execution_time` flag

## Changes
- **BREAKING CHANGE**: Removes `use_script_friendly_output` parameter
- Adds `output_format_mode` enum parameter with options: `'auto'`, `'human_readable'`, `'structured_error'`, `'structured_output_and_error'`, `'direct'`
- Default mode is `'auto'` which intelligently selects appropriate formatting:
  - `human_readable` for AppleScript
  - `direct` for JXA (better Obj-C bridge compatibility)
- Fixed timing measurement to properly report millisecond precision
- Added `report_execution_time` boolean flag for optional time reporting in response

## Test plan
- [ ] Run existing tests to ensure backward compatibility
- [ ] Test AppleScript execution with different output format modes
- [ ] Test JXA execution with different output format modes
- [ ] Verify timing precision is correctly reported
- [ ] Test optional execution time reporting