### PR TITLE
feat: add MCP tool annotations for better LLM understanding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Added MCP tool annotations so clients can distinguish read-only scripting tips from script execution that can modify system state (#171). Thanks @bryankthompson.
 - Fixed `macos-automator-mcp --version` so version checkers print the package version and exit instead of starting the MCP stdio server (#201).
 
 ## [0.4.1] - 2025-05-20

--- a/src/server.ts
+++ b/src/server.ts
@@ -86,6 +86,10 @@ async function main() {
   server.registerTool(
     "execute_script",
     {
+      annotations: {
+        title: 'Execute Script',
+        destructiveHint: true,
+      },
       description: `Automate macOS tasks using AppleScript or JXA (JavaScript for Automation) to control applications like Terminal, Chrome, Safari, Finder, etc.
 
 **1. Script Source (Choose one):**
@@ -372,6 +376,10 @@ async function main() {
   server.registerTool(
     "get_scripting_tips",
     {
+      annotations: {
+        title: 'Get Scripting Tips',
+        readOnlyHint: true,
+      },
       description: `Discover how to automate any app on your Mac with this comprehensive knowledge base of AppleScript/JXA tips and runnable scripts. This tool is essential for discovery and should be the FIRST CHOICE when aiming to automate macOS tasks, especially those involving common applications or system functions, before attempting to write scripts from scratch. It helps identify pre-built, tested solutions, effectively teaching you how to control virtually any aspect of your macOS experience.
 
 **Primary Use Cases & Parameters:**

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,7 +87,7 @@ async function main() {
     "execute_script",
     {
       annotations: {
-        title: 'Execute Script',
+        title: "Execute Script",
         destructiveHint: true,
       },
       description: `Automate macOS tasks using AppleScript or JXA (JavaScript for Automation) to control applications like Terminal, Chrome, Safari, Finder, etc.
@@ -377,7 +377,7 @@ async function main() {
     "get_scripting_tips",
     {
       annotations: {
-        title: 'Get Scripting Tips',
+        title: "Get Scripting Tips",
         readOnlyHint: true,
       },
       description: `Discover how to automate any app on your Mac with this comprehensive knowledge base of AppleScript/JXA tips and runnable scripts. This tool is essential for discovery and should be the FIRST CHOICE when aiming to automate macOS tasks, especially those involving common applications or system functions, before attempting to write scripts from scratch. It helps identify pre-built, tested solutions, effectively teaching you how to control virtually any aspect of your macOS experience.

--- a/tests/mcp-stdio.test.ts
+++ b/tests/mcp-stdio.test.ts
@@ -34,6 +34,12 @@ function shellEscape(value: string) {
   return value.replace(/'/g, "'\\''");
 }
 
+function toolByName(tools: Awaited<ReturnType<Client["listTools"]>>["tools"], name: string) {
+  const tool = tools.find((candidate) => candidate.name === name);
+  expect(tool, `expected MCP tool ${name} to be listed`).toBeDefined();
+  return tool!;
+}
+
 describe("MCP stdio protocol", () => {
   let client: Client;
   let transport: StdioClientTransport;
@@ -65,8 +71,17 @@ describe("MCP stdio protocol", () => {
 
   it("lists tools, returns tips, and executes a script", async () => {
     const { tools } = await client.listTools();
-    expect(tools.some((tool) => tool.name === "get_scripting_tips")).toBe(true);
-    expect(tools.some((tool) => tool.name === "execute_script")).toBe(true);
+    const tipsTool = toolByName(tools, "get_scripting_tips");
+    const executeTool = toolByName(tools, "execute_script");
+
+    expect(tipsTool.annotations).toMatchObject({
+      title: "Get Scripting Tips",
+      readOnlyHint: true,
+    });
+    expect(executeTool.annotations).toMatchObject({
+      title: "Execute Script",
+      destructiveHint: true,
+    });
 
     const tipsResult = await client.callTool({
       name: "get_scripting_tips",
@@ -112,7 +127,7 @@ describe("CLI flags", () => {
         VITEST: "true",
         TSX_TSCONFIG_PATH,
       },
-      timeout: 1000,
+      timeout: 5000,
     });
 
     expect(output.trim()).toBe(packageJson.version);


### PR DESCRIPTION
## Summary
- Add `annotations` to both MCP tools for improved LLM tool selection:
  - `execute_script`: `destructiveHint: true` (can execute arbitrary AppleScript/JXA on the system)
  - `get_scripting_tips`: `readOnlyHint: true` (only queries the knowledge base)
- Fix build failure by removing deprecated `onLog` property from McpServer constructor (not valid in SDK 1.25.1)

## Why Tool Annotations?
Tool annotations help LLMs understand tool behavior before execution:
- `destructiveHint` warns that `execute_script` can modify system state
- `readOnlyHint` indicates `get_scripting_tips` is safe to call without side effects

This follows the [MCP specification for tool annotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#annotations).

## Test plan
- [x] `npm run build` succeeds
- [x] Verified annotations appear in compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)