### PR TITLE
fix(cli): make --version exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `macos-automator-mcp --version` so version checkers print the package version and exit instead of starting the MCP stdio server (#201).
+
 ## [0.4.1] - 2025-05-20
 
 - Fixed version reporting to only occur on tool calls, not MCP initialization handshake

--- a/src/server.ts
+++ b/src/server.ts
@@ -48,6 +48,11 @@ const IS_E2E_TESTING = process.env.MCP_E2E_TESTING === "true" || process.env.VIT
 let hasEmittedFirstCallInfo = false; // Flag for first tool call
 const serverInfoMessage = `MacOS Automator MCP v${pkg.version}, started at ${SERVER_START_TIME_ISO}`;
 
+if (process.argv.includes("--version") || process.argv.includes("-v")) {
+  process.stdout.write(`${pkg.version}\n`);
+  process.exit(0);
+}
+
 const logger = new Logger("macos_automator_server");
 const scriptExecutor = new ScriptExecutor();
 

--- a/tests/mcp-stdio.test.ts
+++ b/tests/mcp-stdio.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { execFileSync } from "node:child_process";
 import path from "path";
 import os from "os";
 import fs from "fs/promises";
+import packageJson from "../package.json" with { type: "json" };
 
 const WORKSPACE_PATH = path.resolve(__dirname, "..");
 const TSX_PATH = path.join(WORKSPACE_PATH, "node_modules", ".bin", "tsx");
@@ -97,4 +99,22 @@ describe("MCP stdio protocol", () => {
       }
     }
   }, 60000);
+});
+
+describe("CLI flags", () => {
+  it("prints version and exits without starting stdio transport", () => {
+    const output = execFileSync(TSX_PATH, [SERVER_PATH, "--version"], {
+      cwd: WORKSPACE_PATH,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        MCP_E2E_TESTING: "true",
+        VITEST: "true",
+        TSX_TSCONFIG_PATH,
+      },
+      timeout: 1000,
+    });
+
+    expect(output.trim()).toBe(packageJson.version);
+  });
 });


### PR DESCRIPTION
## Summary\n- handle `--version` / `-v` before starting the MCP stdio server\n- add a timeout-backed CLI regression test\n- document the user-visible fix in the changelog\n\nFixes #201.\n\n## Proof\n- `pnpm test -- tests/mcp-stdio.test.ts`\n- `pnpm lint && pnpm typecheck && pnpm build && pnpm test`\n- `timeout 2 node dist/server.js --version`\n- `timeout 2 pnpm start -- --version`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an early `--version`/`-v` fast-path and a regression test; no changes to MCP tool behavior beyond preventing unintended server startup on version checks.
> 
> **Overview**
> **Fixes CLI version checks** by handling `--version`/`-v` in `src/server.ts` before initializing the MCP stdio server, printing the package version and exiting immediately.
> 
> Adds a timeout-backed regression test in `tests/mcp-stdio.test.ts` to ensure the process exits and outputs `package.json`’s version, and documents the user-visible fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e88662f681ac2e5ab8abfb08322a9023e9885298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->