### PR TITLE
fix(placeholders): ${inputData.x} and ${arguments[N]} never substitute (over-escaped regex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed JS-style `${inputData.key}` and `${arguments[N]}` placeholder substitution in scripts. Thanks @devYRPauli.
 - Added MCP tool annotations so clients can distinguish read-only scripting tips from script execution that can modify system state (#171). Thanks @bryankthompson.
 - Fixed `macos-automator-mcp --version` so version checkers print the package version and exit instead of starting the MCP stdio server (#201).
 - Fixed the documented VS Code/npm install command to avoid `@latest` package-name validation and scoped-package bin inference issues (#38).

--- a/src/placeholderSubstitutor.ts
+++ b/src/placeholderSubstitutor.ts
@@ -65,7 +65,7 @@ export function substitutePlaceholders({
   };
 
   // JS-style ${inputData.key}
-  const jsInputDataRegex = /\\$\\{inputData\\.(\\w+)\\}/g;
+  const jsInputDataRegex = /\$\{inputData\.(\w+)\}/g;
   logSub("Before jsInputDataRegex", { scriptContentLength: currentScriptContent.length });
   currentScriptContent = currentScriptContent.replace(jsInputDataRegex, (match, keyName) => {
     const snakeKeyName = camelToSnake(keyName); // Convert camelCase from script to snake_case for lookup
@@ -79,7 +79,7 @@ export function substitutePlaceholders({
   logSub("After jsInputDataRegex", { scriptContentLength: currentScriptContent.length });
 
   // JS-style ${arguments[N]}
-  const jsArgumentsRegex = /\\$\\{arguments\\[(\\d+)\\]\\}/g;
+  const jsArgumentsRegex = /\$\{arguments\[(\d+)\]\}/g;
   logSub("Before jsArgumentsRegex", { scriptContentLength: currentScriptContent.length });
   currentScriptContent = currentScriptContent.replace(jsArgumentsRegex, (match, indexStr) => {
     const index = Number.parseInt(indexStr, 10);

--- a/tests/placeholderSubstitutor.test.ts
+++ b/tests/placeholderSubstitutor.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { substitutePlaceholders } from "../src/placeholderSubstitutor.js";
+
+describe("substitutePlaceholders – JS-style ${...} placeholders", () => {
+  it("substitutes ${inputData.key} with the AppleScript literal", () => {
+    const { substitutedScript } = substitutePlaceholders({
+      scriptContent: "display dialog ${inputData.message}",
+      inputData: { message: "hi" },
+      includeSubstitutionLogs: false,
+    });
+    expect(substitutedScript).toBe('display dialog "hi"');
+  });
+
+  it("substitutes ${arguments[N]} with the AppleScript literal at that index", () => {
+    const { substitutedScript } = substitutePlaceholders({
+      scriptContent: "display dialog ${arguments[0]} & ${arguments[1]}",
+      args: ["world", "again"],
+      includeSubstitutionLogs: false,
+    });
+    expect(substitutedScript).toBe('display dialog "world" & "again"');
+  });
+
+  it("maps a camelCase ${inputData.appName} placeholder to the snake_case input_data key", () => {
+    const { substitutedScript } = substitutePlaceholders({
+      scriptContent: "tell application ${inputData.appName}",
+      inputData: { app_name: "Safari" },
+      includeSubstitutionLogs: false,
+    });
+    expect(substitutedScript).toBe('tell application "Safari"');
+  });
+
+  it("emits the AppleScript bare keyword `missing value` for an absent key or out-of-range index", () => {
+    const { substitutedScript } = substitutePlaceholders({
+      scriptContent: "set a to ${inputData.nope}\nset b to ${arguments[5]}",
+      inputData: { message: "hi" },
+      args: ["only-one"],
+      includeSubstitutionLogs: false,
+    });
+    expect(substitutedScript).toBe("set a to missing value\nset b to missing value");
+  });
+
+  it("still substitutes the quoted --MCP_INPUT: style (regression guard)", () => {
+    const { substitutedScript } = substitutePlaceholders({
+      scriptContent: 'display dialog "--MCP_INPUT:message"',
+      inputData: { message: "hi" },
+      includeSubstitutionLogs: false,
+    });
+    expect(substitutedScript).toBe('display dialog "hi"');
+  });
+});


### PR DESCRIPTION
## Problem

Two of the documented placeholder styles never substitute. `docs/spec.md` (line 265) lists `${inputData.keyName}` and `${arguments[N]}` as supported, but a script using them comes out of `substitutePlaceholders` unchanged, so the literal `${inputData.foo}` / `${arguments[0]}` text is handed to `osascript` and the script fails to compile at runtime.

```
display dialog ${inputData.message}
  -> (expected) display dialog "hi"
  -> (actual)   display dialog ${inputData.message}   // unchanged, then osascript errors
```

## Root cause

The two regex literals are over-escaped:

```ts
const jsInputDataRegex = /\\$\\{inputData\\.(\\w+)\\}/g;
const jsArgumentsRegex = /\\$\\{arguments\\[(\\d+)\\]\\}/g;
```

Inside a regex literal `\\` matches a single literal backslash, so these patterns only match input like `\$\{inputData\.foo\}` (with real backslashes), which never occurs in a script. `String.replace` therefore finds nothing and returns the content untouched. The four other placeholder regexes in the same file (the `--MCP_INPUT:` / `--MCP_ARG_N` styles) use correct single-backslash escaping and work fine, which is why only these two styles were affected.

## Fix

Use the correct single-backslash escaping:

```ts
const jsInputDataRegex = /\$\{inputData\.(\w+)\}/g;
const jsArgumentsRegex = /\$\{arguments\[(\d+)\]\}/g;
```

## Tests

`placeholderSubstitutor` had no test file, which is why this stayed silent. Added `tests/placeholderSubstitutor.test.ts` covering both `${...}` styles, the camelCase-to-snake_case key mapping, the `missing value` fallback for an absent key / out-of-range index, and a regression guard that the `--MCP_INPUT:` style still substitutes.

On the unfixed regexes the four `${...}` cases fail and the `--MCP_INPUT:` guard passes, which pins the defect to these two patterns. After the fix the whole suite is green:

```
Test Files  2 passed (2)
     Tests  7 passed (7)
```

`tsgo --noEmit`, `oxfmt --check`, and `oxlint --deny-warnings` are all clean on the changed files.

## Real-run output

Runtime against the real `substitutePlaceholders` module. The `--MCP_INPUT:` control is included to isolate the defect to the two `${...}` regexes.

Before the fix, the `${...}` placeholders pass through untouched and would reach `osascript` verbatim:

```
[inputData JS-style]   out: "display dialog ${inputData.message}"
[arguments JS-style]   out: "display dialog ${arguments[0]}"
[CONTROL --MCP_INPUT]  out: "display dialog \"hi\""
```

After the fix they substitute, and the control is unchanged:

```
[inputData JS-style]   out: "display dialog \"hi\""
[arguments JS-style]   out: "display dialog \"world\""
[CONTROL --MCP_INPUT]  out: "display dialog \"hi\""
```

The new regression test run on the unfixed regexes — the four `${...}` cases fail, the `--MCP_INPUT:` guard still passes:

```
❯ tests/placeholderSubstitutor.test.ts (5 tests | 4 failed)
    × substitutes ${inputData.key} with the AppleScript literal
    × substitutes ${arguments[N]} with the AppleScript literal at that index
    × maps a camelCase ${inputData.appName} placeholder to the snake_case input_data key
    × emits the AppleScript bare keyword `missing value` for an absent key or out-of-range index
    ✓ still substitutes the quoted --MCP_INPUT: style (regression guard)
```

And after the fix:

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Found and fixed with the help of the Claude CLI.
