### PR TITLE
fix(deps): update js-yaml security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Updated the transitive YAML parser used for knowledge-base frontmatter to address a quadratic CPU-exhaustion denial-of-service vulnerability ([GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68)).
+
 ## [0.4.3] - 2026-06-19
 
 - Updated transitive dependency overrides to patched Vite and Hono releases.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,8 +953,8 @@ packages:
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   json-schema-traverse@1.0.0:
@@ -1945,7 +1945,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -1984,7 +1984,7 @@ snapshots:
 
   jose@6.2.3: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1


### PR DESCRIPTION
## Summary

- refresh the locked `gray-matter` transitive from `js-yaml` 3.14.2 to compatible patched 3.15.0
- document the user-facing denial-of-service security impact in the changelog

## Risk

Low: the existing `gray-matter` semver range already accepts 3.15.0; no source, API, runtime contract, package-manager, or compiler changes.

## Verification

- `pnpm audit --prod --json` — zero vulnerabilities
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` — 2 files / 7 tests passed
- `pnpm validate` — 507 files, 492 tips, zero errors
- packed tarball install — resolves `gray-matter -> js-yaml@3.15.0`, npm production audit clean, CLI `--version` prints `0.4.3` and exits
- Codex autoreview — clean, no accepted/actionable findings

Advisory: https://github.com/advisories/GHSA-h67p-54hq-rp68

Public model identifier gate: not applicable; this patch changes no model identifiers.
