### PR TITLE
docs: refresh current usage guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Corrected development, debugging, and knowledge-base validation documentation to match current file paths, commands, and snake_case MCP inputs.
 - Updated Node.js type definitions and the native TypeScript preview compiler used for development and CI.
 
 ## [0.4.4] - 2026-07-01

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Fine-tune your robot's behavior with these environment variables:
 
 ## 👨‍🔬 Robot Scientists Welcome!
 
-Want to upgrade your robot? Check out [DEVELOPMENT.md](DEVELOPMENT.md) for the full technical manual on teaching new tricks to your automation assistant.
+Want to upgrade your robot? Check out the [development guide](docs/DEVELOPMENT.md) for the full technical manual on teaching new tricks to your automation assistant.
 
 ## 🧠 Teach Your Robot New Tricks (Local Knowledge Base)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -65,7 +65,7 @@ macos-automator-mcp/
 ├── .github/workflows/    # GitHub Actions workflows (CI)
 ├── .oxlintrc.json
 ├── .gitignore
-├── DEVELOPMENT.md        # This file
+├── docs/DEVELOPMENT.md   # This file
 ├── LICENSE
 ├── README.md
 ├── pnpm-lock.yaml

--- a/docs/E2E_TESTING_STRATEGIES.md
+++ b/docs/E2E_TESTING_STRATEGIES.md
@@ -5,7 +5,7 @@ This document outlines key strategies and learnings from creating End-to-End (E2
 ## 1. Test Runner Configuration (Vitest)
 
 - **Single Run for CI/Automation:** To ensure Vitest runs tests once and then exits (suitable for CI or automated scripts), use the `run` command.
-  - Example: `npm test -- run --no-file-parallelism <test_file_path>`
+  - Example: `pnpm exec vitest run --no-file-parallelism <test_file_path>`
   - The `--no-file-parallelism` flag was used during development to simplify debugging by running tests sequentially if multiple test files were present. Adjust as needed.
 
 ## 2. MCP Inspector UI Selectors (Playwright)

--- a/docs/debugging_applescript.md
+++ b/docs/debugging_applescript.md
@@ -8,18 +8,18 @@ This guide provides tips and techniques based on common scenarios encountered.
 
 ### 1. Enable Detailed Substitution Logging
 
-When using knowledge base scripts (`knowledgeBaseScriptId`) with the `execute_script` tool, placeholders like `--MCP_INPUT:keyName` and `--MCP_ARG_N` are substituted with values from `inputData` and `arguments` respectively. If this substitution is incorrect, it can lead to AppleScript syntax errors (like the common `-2741 "Expected , or } but found class name."`).
+When using knowledge base scripts (`kb_script_id`) with the `execute_script` tool, placeholders like `--MCP_INPUT:keyName` and `--MCP_ARG_N` are substituted with values from `input_data` and `arguments` respectively. If this substitution is incorrect, it can lead to AppleScript syntax errors (like the common `-2741 "Expected , or } but found class name."`).
 
 To understand exactly how these substitutions are being performed:
 
-- **Use `includeSubstitutionLogs: true`**: Add this parameter to your `execute_script` call.
+- **Use `include_substitution_logs: true`**: Add this parameter to your `execute_script` call.
   ```json
   {
-    "method": "execute_script",
-    "params": {
-      "knowledgeBaseScriptId": "your_script_id",
-      "inputData": { "someKey": "someValue" },
-      "includeSubstitutionLogs": true
+    "toolName": "execute_script",
+    "input": {
+      "kb_script_id": "your_script_id",
+      "input_data": { "some_key": "someValue" },
+      "include_substitution_logs": true
     }
   }
   ```
@@ -50,7 +50,7 @@ This methodical approach helps pinpoint exactly which part of a complex regex is
 
 If a script fails and substitution seems correct, or if it's an inline script or script file:
 
-1.  **Isolate the AppleScript/JXA**: Take the final, substituted script content (available from `includeExecutedScriptInOutput: true` or the error message).
+1.  **Isolate the AppleScript/JXA**: Take the final, substituted script content (available from `include_executed_script_in_output: true` or the error message).
 2.  **Run in Script Editor (for AppleScript) or a JXA environment**: macOS's Script Editor provides better error highlighting and a more direct execution environment.
     - Paste the script content.
     - Run it.
@@ -92,4 +92,4 @@ For JXA, use `console.log()`.
 - **-1712 (errAEEventTimedOut)**: Script took too long, or a hidden permissions dialog might be blocking execution.
 - **-10004 (errAEAccessDenied)**: Typically a file access or permissions issue.
 
-By using these techniques, particularly the `includeSubstitutionLogs` feature and iterative debugging, you can more effectively diagnose and resolve issues with your AppleScript and JXA automations executed via this server.
+By using these techniques, particularly the `include_substitution_logs` feature and iterative debugging, you can more effectively diagnose and resolve issues with your AppleScript and JXA automations executed via this server.

--- a/docs/kb_validation.md
+++ b/docs/kb_validation.md
@@ -8,33 +8,23 @@ The knowledge base consists of Markdown files containing AppleScript and JXA scr
 
 1. Each file has the correct frontmatter metadata (title, description, etc.)
 2. Script IDs are unique across the knowledge base
-3. Scripts have valid syntax (without executing them)
+3. Script blocks and placeholder metadata are internally consistent
 
-## Validation Commands
-
-### Basic Validation
+## Validation Command
 
 ```bash
 pnpm run validate
 ```
 
-This command validates the structure and metadata of all knowledge base files without checking script syntax.
+This command validates the structure and metadata of the embedded knowledge base. It also validates the default local knowledge base at `~/.macos-automator/knowledge_base` when that directory exists.
 
-### Syntax Validation
-
-```bash
-pnpm run validate
-```
-
-This command performs all basic validation checks plus validates the syntax of AppleScript and JXA scripts using the `osascript` command without executing them.
-
-### Testing Specific Files
+To validate a local knowledge base at another path:
 
 ```bash
-pnpm run validate
+pnpm run validate -- --local-kb-path /absolute/path/to/knowledge_base
 ```
 
-This runs validation on a test directory with known valid and invalid scripts for testing purposes.
+The validator always checks the embedded knowledge base as well as the selected local knowledge base.
 
 ## Validation Process
 
@@ -43,12 +33,8 @@ The validation script:
 1. Parses the frontmatter metadata for each file
 2. Checks for required fields (title, description, etc.)
 3. Verifies ID uniqueness
-4. Extracts script content from code blocks
-5. For syntax validation, checks script syntax using:
-   - `osacompile -o /dev/null script.applescript` for AppleScript
-   - `osacompile -l JavaScript -o /dev/null script.js` for JXA
-
-The syntax validation is fail-fast - if a script has syntax errors, the validator will report them without executing the script.
+4. Extracts script content from code blocks and reports missing, empty, or language-mismatched blocks
+5. Checks complex-script argument prompts against MCP placeholders
 
 ## Adding New Scripts
 
@@ -57,7 +43,7 @@ When adding new scripts to the knowledge base:
 1. Create a new `.md` file in the appropriate category folder
 2. Include the required frontmatter metadata
 3. Add the script code in a fenced code block with the correct language tag (`applescript` or `javascript`)
-4. Run `pnpm run validate` to ensure your script is valid
+4. Run `pnpm run validate` to check the entry metadata and script block structure
 5. Fix any reported issues
 
 ## Validation Output
@@ -68,7 +54,6 @@ The validation process produces a report showing:
 - Total tips processed
 - Categories found
 - Validation errors and warnings
-- Script syntax errors (if syntax validation is enabled)
 
 ## Implementation Details
 
@@ -78,16 +63,3 @@ The validation process is implemented in TypeScript in the `scripts/` directory:
 - `kbFileValidator.ts`: File validation logic
 - `kbPathProcessor.ts`: Directory traversal logic
 - `kbReport.ts`: Reporting utilities
-- `scriptValidator.ts`: Script syntax validation logic
-
-The script syntax validation uses the macOS built-in `osacompile` tool to validate without executing, using the approach:
-
-```bash
-# For AppleScript - fast inline validation
-osacompile -e 'tell app "Finder" to beep' -o /dev/null
-
-# For JXA - fast inline validation
-osacompile -l JavaScript -e 'Application("Finder").beep()' -o /dev/null
-```
-
-This approach checks for syntax errors without actually executing the scripts. By compiling to `/dev/null`, we're able to validate syntax while discarding the compiled output. If there are syntax errors, the command will exit with a non-zero status code, making it safe and effective for CI environments.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -34,7 +34,7 @@ macos-automator-mcp/
 ├── docs/
 │   └── spec.md (this file)
 ├── .gitignore
-├── DEVELOPMENT.md
+├── docs/DEVELOPMENT.md
 ├── LICENSE
 ├── README.md
 ├── package.json
@@ -325,7 +325,7 @@ Handles replacing placeholders in scripts fetched from the knowledge base.
 ### 8. Documentation and Startup
 
 - `README.md` should detail tool usage, including `kb_script_id`, `input_data`, placeholder conventions, and permissions.
-- `DEVELOPMENT.md` should explain KB contribution guidelines.
+- `docs/DEVELOPMENT.md` should explain KB contribution guidelines.
 - Server startup logs current working directory and critical permission warnings.
 
 ## Part 2: Knowledge Base Content Specification and Generation


### PR DESCRIPTION
## Summary

- fix the README development-guide link and repository layout references
- update the debugging guide to the current snake_case MCP inputs
- replace stale validator and focused-test commands with the behavior the repository actually supports

## Risk

Low: documentation and changelog only; runtime code, dependencies, and workflows are unchanged.

## Verification

- `pnpm lint`
- `pnpm exec vitest run --no-file-parallelism tests/mcp-stdio.test.ts` — 1 file / 2 tests passed, including real AppleScript over MCP stdio
- `pnpm run validate -- --local-kb-path /tmp/nonexistent-macos-automator-kb-proof` — 507 files, 492 tips, zero errors; five pre-existing conceptual-tip warnings
- current schemas and repository paths cross-checked against every corrected example
- Codex autoreview — initial P2 correctly identified an overstated syntax-validation claim; fixed; final review clean with no accepted or actionable findings

Public model identifier gate: PASS. This docs-only diff introduces no provider model identifiers.

No release, tag, version bump, or registry publication is part of this PR.
