### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # macOS Automator MCP 🤖 - Your Friendly Neighborhood RoboScripter™
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fsteipete%2Fmacos-automator-mcp.svg)](https://mcptoplist.com/server/glama%2Fsteipete%2Fmacos-automator-mcp)
+
 ![macOS Automator MCP Server](assets/logo.png)
 
 ## 🎯 Mission Control: Teaching Robots to Click Buttons Since 2024


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,919 MCP servers across the major
registries, and **macOS Automator MCP Server** is currently ranked **#505**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fsteipete%2Fmacos-automator-mcp.svg)](https://mcptoplist.com/server/glama%2Fsteipete%2Fmacos-automator-mcp)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building macOS Automator MCP Server!
