### PR TITLE
chore(deps): refresh zod, tsx, and transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Updated Zod to 4.5.4 for input-validation fixes and reduced schema memory use.
 - Updated pnpm, Node.js types, formatting and lint tooling, and the Hono override; refreshed transitive dependencies.
 - Rewrote the README around installation and first use, with detailed tool and configuration references moved into `docs/`.
 - Updated development dependencies and refreshed the patched Hono and Vite security overrides.

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
     "@modelcontextprotocol/sdk": "^1.30.0",
     "fuse.js": "^7.5.0",
     "gray-matter": "^4.0.3",
-    "zod": "^4.4.3"
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@types/node": "^26.4.0",
     "oxfmt": "^0.65.0",
     "oxlint": "^1.80.0",
-    "tsx": "^4.23.12",
+    "tsx": "^4.23.13",
     "typescript": "^7.0.2",
     "vitest": "^4.1.11"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
-        version: 1.30.0(zod@4.4.3)
+        version: 1.30.0(zod@4.5.4)
       fuse.js:
         specifier: ^7.5.0
         version: 7.5.0
@@ -23,8 +23,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^4.5.4
+        version: 4.5.4
     devDependencies:
       '@types/node':
         specifier: ^26.4.0
@@ -36,14 +36,14 @@ importers:
         specifier: ^1.80.0
         version: 1.80.0
       tsx:
-        specifier: ^4.23.12
-        version: 4.23.12
+        specifier: ^4.23.13
+        version: 4.23.13
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.12))
+        version: 4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.13))
 
 packages:
 
@@ -209,8 +209,8 @@ packages:
     peerDependencies:
       hono: 4.13.5
 
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
 
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
@@ -880,8 +880,8 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.6.2:
-    resolution: {integrity: sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==}
+  express-rate-limit@8.7.0:
+    resolution: {integrity: sha512-hOwV7WOxXfjRpAM1DSJWZDXx3GhplwD8IfwuwvogD8i1Qnkgosw/H45s4ZnFAUHDAhPjlY9hLBvJhKmGMyY26g==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -972,8 +972,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.5.0:
-    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
+  ip-address@10.7.0:
+    resolution: {integrity: sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1194,8 +1194,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.3.0:
@@ -1308,8 +1308,8 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tsx@4.23.12:
-    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+  tsx@4.23.13:
+    resolution: {integrity: sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -1435,8 +1435,8 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
 snapshots:
 
@@ -1522,9 +1522,9 @@ snapshots:
     dependencies:
       hono: 4.13.5
 
-  '@jridgewell/sourcemap-codec@1.5.5': {}
+  '@jridgewell/sourcemap-codec@1.6.0': {}
 
-  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.5.4)':
     dependencies:
       '@hono/node-server': 2.1.1(hono@4.13.5)
       ajv: 8.20.0
@@ -1535,14 +1535,14 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.1.1
       express: 5.2.1
-      express-rate-limit: 8.6.2(express@5.2.1)
+      express-rate-limit: 8.7.0(express@5.2.1)
       hono: 4.13.5
       jose: 6.2.10
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
+      zod: 4.5.4
+      zod-to-json-schema: 3.25.2(zod@4.5.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -1793,13 +1793,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.12))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.13))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.13)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -1855,7 +1855,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -1973,11 +1973,11 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express-rate-limit@8.6.2(express@5.2.1):
+  express-rate-limit@8.7.0(express@5.2.1):
     dependencies:
       debug: 4.4.3
       express: 5.2.1
-      ip-address: 10.5.0
+      ip-address: 10.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -2003,7 +2003,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -2097,7 +2097,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.5.0: {}
+  ip-address@10.7.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -2171,7 +2171,7 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   math-intrinsics@1.1.0: {}
 
@@ -2278,7 +2278,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1
@@ -2422,7 +2422,7 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tsx@4.23.12:
+  tsx@4.23.13:
     dependencies:
       esbuild: 0.28.2
     optionalDependencies:
@@ -2463,7 +2463,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.12):
+  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.13):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.7
@@ -2474,12 +2474,12 @@ snapshots:
       '@types/node': 26.4.0
       esbuild: 0.28.2
       fsevents: 2.3.3
-      tsx: 4.23.12
+      tsx: 4.23.13
 
-  vitest@4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.12)):
+  vitest@4.1.11(@types/node@26.4.0)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.13)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.12))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.13))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -2496,7 +2496,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.12)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(tsx@4.23.13)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.4.0
@@ -2514,8 +2514,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  zod-to-json-schema@3.25.2(zod@4.4.3):
+  zod-to-json-schema@3.25.2(zod@4.5.4):
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.4
 
-  zod@4.4.3: {}
+  zod@4.5.4: {}


### PR DESCRIPTION
Refresh runtime input validation and the TypeScript runner to their latest stable releases, with the lockfile regenerated by pnpm 11.24.0. Zod's schema-memory and validation fixes warrant the one-line changelog entry; no application code or CI gates change.

## Dependencies

| Package | Before | After |
| --- | --- | --- |
| zod (runtime) | 4.4.3 | 4.5.4 |
| tsx (development) | 4.23.12 | 4.23.13 |
| @jridgewell/sourcemap-codec (transitive) | 1.5.5 | 1.6.0 |
| express-rate-limit (transitive) | 8.6.2 | 8.7.0 |
| ip-address (transitive) | 10.5.0 | 10.7.0 |
| qs (transitive) | 6.15.3 | 6.16.0 |

Reviewed the [Zod 4.5 release notes](https://github.com/colinhacks/zod/releases/tag/v4.5.0), [Zod 4.5.4 fix](https://github.com/colinhacks/zod/releases/tag/v4.5.4), and [tsx cache fix](https://github.com/privatenumber/tsx/releases/tag/v4.23.13). No majors were available to take or skip. All other direct dependencies, pnpm, esbuild/Hono/Vite overrides, and Actions major tags are current (`actions/checkout@v7`, latest v7.0.1; `actions/setup-node@v7`, latest v7.0.0). No dependencies were added or removed.

## Validation and CI reasoning

Default-branch CI was green before this change: [CI run 33142504014](https://github.com/steipete/macos-automator-mcp/actions/runs/33142504014) at dcfe1efd6fb88c6767790c6d5ad3d362cbf3f9fc. The actual CI workflow runs macOS MCP tests, Linux build/lint/typecheck, and Linux knowledge-base validation. The release-triggered Publish Package workflow is separate and was not triggered; Dependabot runs are dependency automation. There are no scheduled production probes or monitoring workflows in this repository.

Local verification used macOS 26.6.2, Node v24.20.0, and pnpm 11.24.0. Commands (Node 24 selected with `PATH=/opt/homebrew/opt/node@24/bin:$PATH`):

```sh
pnpm update --latest
pnpm install --frozen-lockfile
pnpm run build
pnpm test
pnpm run lint
pnpm run typecheck
pnpm run validate
pnpm outdated --format json
pnpm audit
```

Real output excerpts:

```text
Already up to date
Done in 447ms using pnpm v11.24.0
$ tsc
 Test Files  2 passed (2)
      Tests  7 passed (7)
All matched files use the correct format.
$ tsc --noEmit
Total Files Checked: 507
Total Scriptable Tips Parsed: 492
--- ERRORS (0) ---
--- WARNINGS (5) ---
{}
No known vulnerabilities found
```

The five validator warnings identify existing conceptual knowledge-base entries without script blocks. Validation exits successfully with zero errors; no assertions, tests, jobs, or warning policies were weakened.

## Live proof

The compiled CLI was executed directly:

```sh
PATH=/opt/homebrew/opt/node@24/bin:$PATH node dist/server.js --version
# 0.4.6
PATH=/opt/homebrew/opt/node@24/bin:$PATH node .cache/deps-refresh-20260830/live-proof.mjs
```

The proof connects over actual MCP stdio to `dist/server.js`, discovers both tools, searches the bundled knowledge base, executes AppleScript through real `osascript` to read macOS's version, executes real JXA arithmetic, and confirms mutually exclusive script inputs are rejected. The local KB path points to an empty task directory, so the proof does not depend on personal knowledge-base content.

```text
server: macos_automator 0.4.6
tools: execute_script, get_scripting_tips
knowledge-base search: How to Use This Knowledge Base
AppleScript: macOS 26.6.2
JXA: {"sum":42,"language":"JXA"}
invalid input: mutually exclusive script sources rejected
LIVE PROOF PASSED
```

<details>
<summary>Exact live-proof script (save as .cache/deps-refresh-20260830/live-proof.mjs)</summary>

```js
import assert from 'node:assert/strict';
import { execFileSync } from 'node:child_process';
import { Client } from '@modelcontextprotocol/sdk/client/index.js';
import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';

const client = new Client({ name: 'dependency-refresh-proof', version: '1.0.0' });
const transport = new StdioClientTransport({
  command: process.execPath,
  args: ['dist/server.js'],
  cwd: process.cwd(),
  stderr: 'pipe',
  env: { LOG_LEVEL: 'ERROR', LOCAL_KB_PATH: `${process.cwd()}/.cache/deps-refresh-20260830/empty-kb` },
});
const text = (result) => (result.content ?? []).filter((item) => item.type === 'text').map((item) => item.text).join('\n');
try {
  await client.connect(transport);
  console.log(`server: ${client.getServerVersion().name} ${client.getServerVersion().version}`);
  const { tools } = await client.listTools();
  assert.deepEqual(tools.map((tool) => tool.name).sort(), ['execute_script', 'get_scripting_tips']);
  console.log(`tools: ${tools.map((tool) => tool.name).sort().join(', ')}`);
  const tips = await client.callTool({ name: 'get_scripting_tips', arguments: { search_term: 'knowledge base', limit: 1 } });
  assert.match(text(tips), /How to Use This Knowledge Base/);
  console.log('knowledge-base search: How to Use This Knowledge Base');
  const apple = await client.callTool({ name: 'execute_script', arguments: { script_content: 'do shell script "sw_vers -productVersion"' } });
  const macOSVersion = execFileSync('/usr/bin/sw_vers', ['-productVersion'], { encoding: 'utf8' }).trim();
  assert.equal(apple.isError, false);
  assert.match(text(apple), new RegExp(macOSVersion.replaceAll('.', '\\.')));
  console.log(`AppleScript: macOS ${macOSVersion}`);
  const jxa = await client.callTool({ name: 'execute_script', arguments: { script_content: 'JSON.stringify({sum: 19 + 23, language: "JXA"})', language: 'javascript' } });
  assert.equal(jxa.isError, false);
  assert.match(text(jxa), /\{"sum":42,"language":"JXA"\}/);
  console.log('JXA: {"sum":42,"language":"JXA"}');
  const invalid = await client.callTool({ name: 'execute_script', arguments: { script_content: 'return "should not execute"', script_path: '/nonexistent.applescript' } });
  assert.equal(invalid.isError, true);
  assert.match(text(invalid), /Exactly one of/);
  console.log('invalid input: mutually exclusive script sources rejected');
} finally {
  await client.close();
}
console.log('LIVE PROOF PASSED');
```

</details>

Codex autoreview completed with `scoped-clean`: no accepted/actionable findings at the requested default P0 priority.

PR CI also passed on the first run: [CI run 33381091656](https://github.com/steipete/macos-automator-mcp/actions/runs/33381091656) at 49ccbd7ce3a267fa0bdc6efe81a611abbe3c684d. All three jobs succeeded: MCP Stdio Tests (Node 24.x), Build and Lint (24.x), and Validate Knowledge Base. No CI fix or rerun was required.
